### PR TITLE
Use unnamed entry for project name when there is no package to infer from

### DIFF
--- a/src/main/java/io/testproject/sdk/internal/reporting/inferrers/GenericInferrer.java
+++ b/src/main/java/io/testproject/sdk/internal/reporting/inferrers/GenericInferrer.java
@@ -59,7 +59,7 @@ public class GenericInferrer implements ReportSettingsInferrer {
             return getUnnamedEntries();
         }
 
-        String projectName = clazz.getPackageName();
+        String projectName = getPackageName(clazz);
         String jobName = firstTrace.getClassName();
 
         return new ReportSettings(projectName, jobName);

--- a/src/main/java/io/testproject/sdk/internal/reporting/inferrers/JUnitInferrer.java
+++ b/src/main/java/io/testproject/sdk/internal/reporting/inferrers/JUnitInferrer.java
@@ -93,7 +93,7 @@ public class JUnitInferrer implements ReportSettingsInferrer {
                 // If JUnit's DisplayName annotation was found -> return it.
                 // Otherwise -> return clazz package name and clazz simple name
                 return Objects.requireNonNullElseGet(result, () ->
-                        new ReportSettings(clazz.getPackageName(), clazz.getSimpleName()));
+                        new ReportSettings(getPackageName(clazz), clazz.getSimpleName()));
             }
         }
 
@@ -117,9 +117,7 @@ public class JUnitInferrer implements ReportSettingsInferrer {
 
         try {
             Method valueMethod = annotation.get().annotationType().getDeclaredMethod(JUNIT5_DISPLAY_NAME_VALUE);
-            return new ReportSettings(
-                    clazz.getPackageName(),
-                    valueMethod.invoke(annotation.get()).toString());
+            return new ReportSettings(getPackageName(clazz), valueMethod.invoke(annotation.get()).toString());
         } catch (IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
             LOG.error("Failed to infer JobName from DisplayName annotation", e);
             return null;

--- a/src/main/java/io/testproject/sdk/internal/reporting/inferrers/ReportSettingsInferrer.java
+++ b/src/main/java/io/testproject/sdk/internal/reporting/inferrers/ReportSettingsInferrer.java
@@ -18,6 +18,7 @@
 package io.testproject.sdk.internal.reporting.inferrers;
 
 import io.testproject.sdk.internal.rest.ReportSettings;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,6 +48,16 @@ public interface ReportSettingsInferrer {
     default ReportSettings getUnnamedEntries() {
         LOG.info("Failed to infer Project and Job names, will use default 'Unnamed' values.");
         return new ReportSettings("Unnamed Project", "Unnamed Job");
+    }
+
+    /**
+     * Get class package name, or if it's empty, the unnamed entry.
+     * @param clazz Class to infer it's package name.
+     * @return class package name, or if it's empty, the unnamed entry.
+     */
+    default String getPackageName(Class<?> clazz) {
+        return StringUtils.isEmpty(clazz.getPackageName())
+                ? getUnnamedEntries().getProjectName() : clazz.getPackageName();
     }
 
     /**

--- a/src/main/java/io/testproject/sdk/internal/reporting/inferrers/TestNGInferrer.java
+++ b/src/main/java/io/testproject/sdk/internal/reporting/inferrers/TestNGInferrer.java
@@ -95,7 +95,7 @@ public class TestNGInferrer implements ReportSettingsInferrer {
                 // If TestNG @BeforeClass or @BeforeSuite annotations with description were found -> return it.
                 // Otherwise -> return clazz package name and clazz simple name
                 return Objects.requireNonNullElseGet(result, () ->
-                        new ReportSettings(clazz.getPackageName(), clazz.getSimpleName()));
+                        new ReportSettings(getPackageName(clazz), clazz.getSimpleName()));
             }
         }
 
@@ -143,7 +143,7 @@ public class TestNGInferrer implements ReportSettingsInferrer {
                 String description = descriptionMethod.invoke(annotation.get()).toString();
 
                 if (!StringUtils.isEmpty(description)) {
-                    return new ReportSettings(clazz.getPackageName(), description);
+                    return new ReportSettings(getPackageName(clazz), description);
                 }
 
                 // Description is empty


### PR DESCRIPTION
It's is not mandatory to place classes in a package, not under `src > main` neither under `src > test`.

If this is the case, infer logic using `getPackageName()` method on `Class` objects, will get an empty string that will be used for project name when opening a development session with the Agent.

This will result in a missing information for report creation and session will be initialized without reporting responding to SDK with 202 HTTP status. Any further reporting commands will result in error 406.

Added logic to use the _unnamed_ entry (`Unnamed Project`) as project name when there is no package wrapping the class.