### PR TITLE
Add a custom capability 'cloud:URL' and relevant documentation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,7 @@ jobs:
       env:
         TP_DEV_TOKEN: ${{ secrets.TP_DEV_TOKEN }}
         TP_AGENT_URL: http://localhost:8585
+        TP_CLOUD_URL: ${{ secrets.TP_CLOUD_URL }}
       run: |
         trap 'kill $(jobs -p)' EXIT
         export TP_DEBUG_SDK_VERSION=$SDK_VERSION

--- a/README.md
+++ b/README.md
@@ -151,6 +151,23 @@ public ChromeDriver(final URL remoteAddress, final ChromeOptions options)
 
 It can also be set using the `TP_AGENT_URL` environment variable.
 
+## Remote (Cloud) Driver
+
+By default, TestProject Agent communicates with the local Selenium or Appium server. \
+In order to initialize a remote driver for cloud providers such as SauceLabs or BrowserStack, \
+a custom capability `cloud:URL` should be set, for example:
+
+```java
+import io.testproject.sdk.drivers.web.ChromeDriver;
+import io.testproject.sdk.drivers.TestProjectCapabilityType;
+
+ChromeOptions chromeOptions = new ChromeOptions();
+chromeOptions.setCapability(
+        TestProjectCapabilityType.CLOUD_URL,
+        "https://{USERNAME}:{PASSWORD}@ondemand.us-west-1.saucelabs.com:443/wd/hub");
+ChromeDriver driver = new ChromeDriver(chromeOptions);
+```
+
 ## Driver Builder
 
 The SDK provides a generic builder for the drivers - `DriverBuilder`, for example:

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id 'io.codearte.nexus-staging' version '0.21.2'
+    id 'com.adarshr.test-logger' version '2.1.0'
 }
 
 println("> Using Java: " + JavaVersion.current())

--- a/src/main/java/io/testproject/sdk/drivers/TestProjectCapabilityType.java
+++ b/src/main/java/io/testproject/sdk/drivers/TestProjectCapabilityType.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2020 TestProject LTD. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.testproject.sdk.drivers;
+
+/**
+ * Custom capabilities provided by TestProject.
+ */
+public final class TestProjectCapabilityType {
+
+    /**
+     * Custom capability to specify cloud provider URL for the driver initialization.
+     */
+    public static final String CLOUD_URL = "cloud:URL";
+
+    /**
+     * Private constructor to prevent creating instances of this final class.
+     */
+    private TestProjectCapabilityType() { }
+
+}

--- a/src/test/java/io/testproject/sdk/tests/ci/drivers/ChromeDriverTest.java
+++ b/src/test/java/io/testproject/sdk/tests/ci/drivers/ChromeDriverTest.java
@@ -22,11 +22,7 @@ import io.testproject.sdk.internal.exceptions.AgentConnectException;
 import io.testproject.sdk.internal.exceptions.InvalidTokenException;
 import io.testproject.sdk.internal.exceptions.ObsoleteVersionException;
 import io.testproject.sdk.tests.flows.AutomationFlows;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.jupiter.api.*;
 import org.openqa.selenium.chrome.ChromeOptions;
 
 import java.io.IOException;
@@ -34,7 +30,6 @@ import java.io.IOException;
 /**
  * Runs tests on {@link ChromeDriver}.
  */
-@EnabledIfEnvironmentVariable(named = "TP_DEV_TOKEN", matches = ".*?")
 @DisplayName("Chrome Driver")
 class ChromeDriverTest {
 
@@ -45,6 +40,8 @@ class ChromeDriverTest {
 
     @BeforeAll
     static void setup() throws InvalidTokenException, AgentConnectException, ObsoleteVersionException, IOException {
+        Assertions.assertNotNull(System.getenv().get("TP_DEV_TOKEN"));
+
         ChromeOptions options = new ChromeOptions();
         options.setHeadless(true);
         driver = new ChromeDriver(options, "CI - Java");

--- a/src/test/java/io/testproject/sdk/tests/ci/drivers/CloudDriverTest.java
+++ b/src/test/java/io/testproject/sdk/tests/ci/drivers/CloudDriverTest.java
@@ -24,7 +24,6 @@ import io.testproject.sdk.internal.exceptions.InvalidTokenException;
 import io.testproject.sdk.internal.exceptions.ObsoleteVersionException;
 import io.testproject.sdk.tests.flows.AutomationFlows;
 import org.junit.jupiter.api.*;
-import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.openqa.selenium.chrome.ChromeOptions;
 
 import java.io.IOException;
@@ -32,7 +31,6 @@ import java.io.IOException;
 /**
  * Runs tests on {@link ChromeDriver}.
  */
-@EnabledIfEnvironmentVariable(named = "TP_DEV_TOKEN", matches = ".*?")
 @DisplayName("Cloud Driver")
 class CloudDriverTest {
 
@@ -43,7 +41,8 @@ class CloudDriverTest {
 
     @BeforeAll
     static void setup() throws InvalidTokenException, AgentConnectException, ObsoleteVersionException, IOException {
-        Assumptions.assumeTrue(System.getenv().containsKey("TP_CLOUD_URL"));
+        Assertions.assertNotNull(System.getenv().get("TP_DEV_TOKEN"));
+        Assertions.assertNotNull(System.getenv().get("TP_CLOUD_URL"));
 
         ChromeOptions options = new ChromeOptions();
         options.setCapability(TestProjectCapabilityType.CLOUD_URL, System.getenv().get("TP_CLOUD_URL"));

--- a/src/test/java/io/testproject/sdk/tests/ci/drivers/CloudDriverTest.java
+++ b/src/test/java/io/testproject/sdk/tests/ci/drivers/CloudDriverTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2020 TestProject LTD. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.testproject.sdk.tests.ci.drivers;
+
+import io.testproject.sdk.drivers.TestProjectCapabilityType;
+import io.testproject.sdk.drivers.web.ChromeDriver;
+import io.testproject.sdk.internal.exceptions.AgentConnectException;
+import io.testproject.sdk.internal.exceptions.InvalidTokenException;
+import io.testproject.sdk.internal.exceptions.ObsoleteVersionException;
+import io.testproject.sdk.tests.flows.AutomationFlows;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.openqa.selenium.chrome.ChromeOptions;
+
+import java.io.IOException;
+
+/**
+ * Runs tests on {@link ChromeDriver}.
+ */
+@EnabledIfEnvironmentVariable(named = "TP_DEV_TOKEN", matches = ".*?")
+@DisplayName("Cloud Driver")
+class CloudDriverTest {
+
+    /**
+     * Driver instance.
+     */
+    private static ChromeDriver driver;
+
+    @BeforeAll
+    static void setup() throws InvalidTokenException, AgentConnectException, ObsoleteVersionException, IOException {
+        Assumptions.assumeTrue(System.getenv().containsKey("TP_CLOUD_URL"));
+
+        ChromeOptions options = new ChromeOptions();
+        options.setCapability(TestProjectCapabilityType.CLOUD_URL, System.getenv().get("TP_CLOUD_URL"));
+        driver = new ChromeDriver(options, "CI - Java");
+    }
+
+    @Test
+    @DisplayName("Example Test on Cloud Driver")
+    void testExample() {
+        AutomationFlows.runFlow(driver);
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (driver != null) {
+            driver.quit();
+        }
+    }
+}

--- a/src/test/java/io/testproject/sdk/tests/ci/drivers/FirefoxDriverTest.java
+++ b/src/test/java/io/testproject/sdk/tests/ci/drivers/FirefoxDriverTest.java
@@ -22,11 +22,7 @@ import io.testproject.sdk.internal.exceptions.AgentConnectException;
 import io.testproject.sdk.internal.exceptions.InvalidTokenException;
 import io.testproject.sdk.internal.exceptions.ObsoleteVersionException;
 import io.testproject.sdk.tests.flows.AutomationFlows;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.jupiter.api.*;
 import org.openqa.selenium.firefox.FirefoxOptions;
 
 import java.io.IOException;
@@ -34,7 +30,6 @@ import java.io.IOException;
 /**
  * Runs tests on {@link FirefoxDriver}.
  */
-@EnabledIfEnvironmentVariable(named = "TP_DEV_TOKEN", matches = ".*?")
 @DisplayName("Firefox Driver")
 class FirefoxDriverTest {
 
@@ -45,6 +40,8 @@ class FirefoxDriverTest {
 
     @BeforeAll
     static void setup() throws InvalidTokenException, AgentConnectException, ObsoleteVersionException, IOException {
+        Assertions.assertNotNull(System.getenv().get("TP_DEV_TOKEN"));
+
         FirefoxOptions options = new FirefoxOptions();
         options.setHeadless(true);
         driver = new FirefoxDriver(options, "CI - Java");

--- a/src/test/java/io/testproject/sdk/tests/ci/internal/rest/AgentClientTest.java
+++ b/src/test/java/io/testproject/sdk/tests/ci/internal/rest/AgentClientTest.java
@@ -19,7 +19,6 @@ package io.testproject.sdk.tests.ci.internal.rest;
 
 import io.testproject.sdk.internal.exceptions.AgentConnectException;
 import io.testproject.sdk.internal.exceptions.InvalidTokenException;
-import io.testproject.sdk.internal.exceptions.ObsoleteVersionException;
 import io.testproject.sdk.internal.rest.AgentClient;
 import io.testproject.sdk.internal.rest.ReportSettings;
 import org.junit.jupiter.api.DisplayName;
@@ -28,10 +27,9 @@ import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.openqa.selenium.chrome.ChromeOptions;
 
-import java.net.MalformedURLException;
 import java.net.URL;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @DisplayName("AgentClient")
 class AgentClientTest {
@@ -60,22 +58,6 @@ class AgentClientTest {
     }
 
     @Test
-    @DisplayName("Empty token in TP_DEV_TOKEN")
-    @EnabledIfEnvironmentVariable(named = "TP_DEV_TOKEN", matches = REGEX_EMPTY)
-    void testEmptyTokenEnv() {
-        assertThrows(InvalidTokenException.class, () ->
-                AgentClient.getClient(new ChromeOptions(), new ReportSettings("CI - Java", null)));
-    }
-
-    @Test
-    @EnabledIfEnvironmentVariable(named = "TP_AGENT_URL", matches = REGEX_EMPTY)
-    @DisplayName("Malformed URL in TP_AGENT_URL")
-    void testMalformedRemoteAddress() {
-        assertThrows(MalformedURLException.class, () ->
-                AgentClient.getClient(new ChromeOptions(), new ReportSettings("CI - Java", null)));
-    }
-
-    @Test
     @DisplayName("Unknown hostname")
     @EnabledIfEnvironmentVariable(named = "TP_DEV_TOKEN", matches = REGEX_NOT_EMPTY)
     void testUnknownRemoteAddress() {
@@ -92,32 +74,5 @@ class AgentClientTest {
         assertThrows(AgentConnectException.class, () ->
                 AgentClient.getClient(new URL("http://localhost:0"), new ChromeOptions(),
                         new ReportSettings("CI - Java", null)));
-    }
-
-    @Test
-    @DisplayName("Invalid non-empty Token")
-    @DisabledIfEnvironmentVariable(named = "TP_AGENT_URL", matches = REGEX_NOT_EMPTY)
-    void testInvalidToken() {
-        assertThrows(InvalidTokenException.class, () -> {
-            try (AgentClient agentClient = AgentClient.getClient(INVALID_TOKEN, new ChromeOptions(),
-                    new ReportSettings("CI - Java", null))) {
-                assertNull(agentClient);
-            }
-        });
-    }
-
-    @Test
-    @DisplayName("Default remote address")
-    @EnabledIfEnvironmentVariable(named = "TP_DEV_TOKEN", matches = REGEX_NOT_EMPTY)
-    @DisabledIfEnvironmentVariable(named = "TP_AGENT_URL", matches = REGEX_NOT_EMPTY)
-    void testDefaultRemoteAddress() throws
-            InvalidTokenException,
-            AgentConnectException,
-            MalformedURLException,
-            ObsoleteVersionException {
-        ChromeOptions options = new ChromeOptions();
-        options.setHeadless(true);
-        AgentClient.getClient(options, new ReportSettings("CI - Java", null));
-        AgentClient.cleanup();
     }
 }


### PR DESCRIPTION
If cloud:URL is capability set, Agent (0.63.11+) will attempt to initialize a driver using provided URL of a cloud provider such as BrowserStack or SauceLabs.
