### PR TITLE
Version bump to 0.64.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.64.0] - 2020-09-08
+
+### Added 
+
+- SDK will keep a development session open and only restart the driver when reporting the same Job (only when working with Agent 0.64.20 or newer).
+
 ## [0.63.5] - 2020-08-28
 
 ### Added 

--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ For a Maven project, add the following to your `pom.xml` file:
 <dependency>
   <groupId>io.testproject</groupId>
   <artifactId>java-sdk</artifactId>
-  <version>0.63.5-RELEASE</version>
+  <version>0.64.0-RELEASE</version>
   <classifier>sources</classifier>
 </dependency>
 ```
 
 For a Gradle project, add the following to your `build.gradle` file:
 ```
-implementation 'io.testproject:java-sdk:0.63.5-RELEASE'
+implementation 'io.testproject:java-sdk:0.64.0-RELEASE'
 ```
 
 # Test Development


### PR DESCRIPTION
## [0.64.0] - 2020-09-08

### Added 

- SDK will keep a development session open and only restart the driver when reporting the same Job (only when working with Agent 0.64.20 or newer).