### PR TITLE
Closed the agent client when the driver quits.

### DIFF
--- a/src/main/java/io/testproject/sdk/drivers/android/AndroidDriver.java
+++ b/src/main/java/io/testproject/sdk/drivers/android/AndroidDriver.java
@@ -403,6 +403,9 @@ public class AndroidDriver<T extends WebElement>
         ReportingCommandsExecutor executor = (ReportingCommandsExecutor) this.getCommandExecutor();
         executor.clearStash();
 
+        // Close resources.
+        executor.getAgentClient().close();
+
         // It will only trigger test reporting if required.
         // Actual mobile session must be preserved for re-use.
         super.quit();

--- a/src/main/java/io/testproject/sdk/drivers/ios/IOSDriver.java
+++ b/src/main/java/io/testproject/sdk/drivers/ios/IOSDriver.java
@@ -401,6 +401,9 @@ public class IOSDriver<T extends WebElement>
         ReportingCommandsExecutor executor = (ReportingCommandsExecutor) this.getCommandExecutor();
         executor.clearStash();
 
+        // Close resources.
+        executor.getAgentClient().close();
+
         // It will only trigger test reporting if required.
         // Actual mobile session must be preserved for re-use.
         super.quit();

--- a/src/main/java/io/testproject/sdk/drivers/web/ChromeDriver.java
+++ b/src/main/java/io/testproject/sdk/drivers/web/ChromeDriver.java
@@ -411,6 +411,9 @@ public class ChromeDriver extends org.openqa.selenium.chrome.ChromeDriver implem
         ReportingCommandsExecutor executor = (ReportingCommandsExecutor) this.getCommandExecutor();
         executor.clearStash();
 
+        // Close resources.
+        executor.getAgentClient().close();
+
         // Quit the driver to close Selenium session
         super.quit();
     }

--- a/src/main/java/io/testproject/sdk/drivers/web/EdgeDriver.java
+++ b/src/main/java/io/testproject/sdk/drivers/web/EdgeDriver.java
@@ -415,6 +415,9 @@ public class EdgeDriver extends org.openqa.selenium.edge.EdgeDriver implements R
         ReportingCommandsExecutor executor = (ReportingCommandsExecutor) this.getCommandExecutor();
         executor.clearStash();
 
+        // Close resources.
+        executor.getAgentClient().close();
+
         // Quit the driver to close Selenium session
         super.quit();
     }

--- a/src/main/java/io/testproject/sdk/drivers/web/FirefoxDriver.java
+++ b/src/main/java/io/testproject/sdk/drivers/web/FirefoxDriver.java
@@ -415,6 +415,9 @@ public class FirefoxDriver extends org.openqa.selenium.firefox.FirefoxDriver imp
         ReportingCommandsExecutor executor = (ReportingCommandsExecutor) this.getCommandExecutor();
         executor.clearStash();
 
+        // Close resources.
+        executor.getAgentClient().close();
+
         // Quit the driver to close Selenium session
         super.quit();
     }

--- a/src/main/java/io/testproject/sdk/drivers/web/InternetExplorerDriver.java
+++ b/src/main/java/io/testproject/sdk/drivers/web/InternetExplorerDriver.java
@@ -413,6 +413,9 @@ public class InternetExplorerDriver extends org.openqa.selenium.ie.InternetExplo
         ReportingCommandsExecutor executor = (ReportingCommandsExecutor) this.getCommandExecutor();
         executor.clearStash();
 
+        // Close resources.
+        executor.getAgentClient().close();
+
         // Quit the driver to close Selenium session
         super.quit();
     }

--- a/src/main/java/io/testproject/sdk/drivers/web/RemoteWebDriver.java
+++ b/src/main/java/io/testproject/sdk/drivers/web/RemoteWebDriver.java
@@ -391,6 +391,9 @@ public class RemoteWebDriver extends org.openqa.selenium.remote.RemoteWebDriver 
         ReportingCommandsExecutor executor = (ReportingCommandsExecutor) this.getCommandExecutor();
         executor.clearStash();
 
+        // Close resources.
+        executor.getAgentClient().close();
+
         // Quit the driver to close Selenium session
         super.quit();
     }

--- a/src/main/java/io/testproject/sdk/drivers/web/SafariDriver.java
+++ b/src/main/java/io/testproject/sdk/drivers/web/SafariDriver.java
@@ -413,6 +413,9 @@ public class SafariDriver extends org.openqa.selenium.safari.SafariDriver implem
         ReportingCommandsExecutor executor = (ReportingCommandsExecutor) this.getCommandExecutor();
         executor.clearStash();
 
+        // Close resources.
+        executor.getAgentClient().close();
+
         // Quit the driver to close Selenium session
         super.quit();
     }


### PR DESCRIPTION
If the agent client is not closed once the driver quits, the last item is not sent to the reporting queue, which blocks the process from finishing. 
Once the item is sent, the reporting queue stops, and the thread ends, allowing the process to exit.