### PR TITLE
Upgrade Google Core Library - Guava - to latest available version - 29.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,12 @@ repositories {
 dependencies {
 
     // Java client for Appium Mobile Webdriver
-    api group: 'io.appium', name: 'java-client', version: '7.3.0'
+    api (group: 'io.appium', name: 'java-client', version: '7.3.0') {
+        exclude group: 'com.google.guava', module: 'guava'
+    }
+
+    // Guava
+    api group: 'com.google.guava', name: 'guava', version: '29.0-jre'
 
     // JUnit4
     testImplementation group: 'junit', name: 'junit', version: '4.13'


### PR DESCRIPTION
Appium java-client 7.3.0 has a transitive dependency for version 25 that doesn't have a support for collections streaming.
ChromeOptions is a newer class that uses the .asMap() streaming method and needs it, otherwise NoSuchMethodError is thrown in runtime.

Signed-off-by: Marat Strelets <marat@testproject.io>