### PR TITLE
Continue when failed to create a class object for it's name, during test name inferring.

### DIFF
--- a/src/main/java/io/testproject/sdk/internal/reporting/inferrers/TestNGInferrer.java
+++ b/src/main/java/io/testproject/sdk/internal/reporting/inferrers/TestNGInferrer.java
@@ -170,10 +170,9 @@ public class TestNGInferrer implements ReportSettingsInferrer {
             try {
                 clazz = Class.forName(stackTraceElement.getClassName());
             } catch (ClassNotFoundException e) {
-                LOG.error("Failed to create an instance of a class", e);
-
-                // Return a name of the first method in call stack.
-                return traces.get(traces.size() - 1).getMethodName();
+                LOG.debug("Failed to create an instance of a class [{}]: {}",
+                        stackTraceElement.getClassName(), e.getMessage());
+                continue;
             }
 
             // Find the method


### PR DESCRIPTION
In some cases, stack-trace might contain classes that can not be instantiated.

Usually these are classes dynamically generated during reflection such as proxy classes used by Selenium page object model (POM). 

Instead of breaking the loop of iterating over the stack-traces and using the very first item in the list, loop should continue.

Here's an example of a failing stack-trace:

`java.lang.ClassNotFoundException: jdk.internal.reflect.GeneratedMethodAccessor10
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:583)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
	at java.base/java.lang.Class.forName0(Native Method)
	at java.base/java.lang.Class.forName(Class.java:332)
	at io.testproject.sdk.internal.reporting.inferrers.TestNGInferrer.inferTestName(TestNGInferrer.java:171)
	at io.testproject.sdk.internal.helpers.ReportingCommandsExecutor.inferTestName(ReportingCommandsExecutor.java:220)
	at io.testproject.sdk.internal.helpers.ReportingCommandsExecutor.reportTest(ReportingCommandsExecutor.java:186)
	at io.testproject.sdk.internal.helpers.ReportingCommandsExecutor.reportCommand(ReportingCommandsExecutor.java:152)
	at io.testproject.sdk.internal.helpers.CustomAppiumCommandExecutor.execute(CustomAppiumCommandExecutor.java:128)
	at io.testproject.sdk.internal.helpers.CustomAppiumCommandExecutor.execute(CustomAppiumCommandExecutor.java:106)
	at org.openqa.selenium.remote.RemoteWebDriver.execute(RemoteWebDriver.java:543)
	at io.appium.java_client.DefaultGenericMobileDriver.execute(DefaultGenericMobileDriver.java:42)
	at io.appium.java_client.AppiumDriver.execute(AppiumDriver.java:1)
	at io.appium.java_client.android.AndroidDriver.execute(AndroidDriver.java:1)
	at org.openqa.selenium.remote.RemoteWebElement.execute(RemoteWebElement.java:276)
	at io.appium.java_client.DefaultGenericMobileElement.execute(DefaultGenericMobileElement.java:45)
	at io.appium.java_client.MobileElement.execute(MobileElement.java:1)
	at io.appium.java_client.android.AndroidElement.execute(AndroidElement.java:1)
	at org.openqa.selenium.remote.RemoteWebElement.isDisplayed(RemoteWebElement.java:317)
	at jdk.internal.reflect.GeneratedMethodAccessor10.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:567)
	at io.appium.java_client.pagefactory.ElementInterceptor.getObject(ElementInterceptor.java:40)
	at io.appium.java_client.pagefactory.interceptors.InterceptorOfASingleElement.intercept(InterceptorOfASingleElement.java:61)
	at io.appium.java_client.android.AndroidElement$$EnhancerByCGLIB$$b598166c.isDisplayed(<generated>)
	at org.openqa.selenium.support.ui.ExpectedConditions.elementIfVisible(ExpectedConditions.java:315)
	at org.openqa.selenium.support.ui.ExpectedConditions.access$100(ExpectedConditions.java:44)
	at org.openqa.selenium.support.ui.ExpectedConditions$10.apply(ExpectedConditions.java:301)
	at org.openqa.selenium.support.ui.ExpectedConditions$10.apply(ExpectedConditions.java:298)
	at org.openqa.selenium.support.ui.ExpectedConditions$23.apply(ExpectedConditions.java:686)
	at org.openqa.selenium.support.ui.ExpectedConditions$23.apply(ExpectedConditions.java:682)
	at org.openqa.selenium.support.ui.FluentWait.until(FluentWait.java:248)`

