### PR TITLE
Convert strings into the relevant type when setting addon action output.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,8 @@ jobs:
       run: |
         SDK_VERSION=$(git describe --tags || echo v0.0.0-$(git rev-list --all --count)-g$(git rev-parse --short HEAD))
         SDK_VERSION="${SDK_VERSION:1}"
-        echo "::set-env name=SDK_VERSION::$SDK_VERSION"
+        echo "SDK_VERSION=${SDK_VERSION}"
+        echo "TP_SDK_VERSION=${SDK_VERSION}" >> $GITHUB_ENV
     - name: Mark build as release
       if: startsWith(github.ref, 'refs/tags/v')
       run: echo "::set-env name=SDK_BUILD_ARGS::$(echo '-Prelease=true')"
@@ -31,7 +32,7 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle
-      run: ./gradlew build -x test -Pversion=$SDK_VERSION $SDK_BUILD_ARGS
+      run: ./gradlew build -x test -Pversion=$TP_SDK_VERSION $SDK_BUILD_ARGS
     - name: Run TestProject Agent
       env:
         TP_API_KEY: ${{ secrets.TP_API_KEY }}
@@ -62,9 +63,9 @@ jobs:
         TP_CLOUD_URL: ${{ secrets.TP_CLOUD_URL }}
       run: |
         trap 'kill $(jobs -p)' EXIT
-        export TP_DEBUG_SDK_VERSION=$SDK_VERSION
+        export TP_DEBUG_SDK_VERSION=$TP_SDK_VERSION
         docker-compose -f docker-compose.yml logs -f --tail=0 >> build/reports/agent/log.txt&
-        ./gradlew test --tests io.testproject.sdk.tests.ci.* -Pversion=$SDK_VERSION $SDK_BUILD_ARGS
+        ./gradlew test --tests io.testproject.sdk.tests.ci.* -Pversion=$TP_SDK_VERSION $SDK_BUILD_ARGS
     - name: Upload to Maven
       if: startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/heads/master')
       env:
@@ -72,7 +73,7 @@ jobs:
         ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_PASSPHRASE }}
         ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.OSSRH_USERNAME }}
         ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.OSSRH_PASSWORD }}        
-      run: ./gradlew publish -Pversion=$SDK_VERSION $SDK_BUILD_ARGS
+      run: ./gradlew publish -Pversion=$TP_SDK_VERSION $SDK_BUILD_ARGS
     - name: Publish to Maven
       if: startsWith(github.ref, 'refs/tags/v')
       env:

--- a/src/main/java/io/testproject/sdk/internal/addons/AddonsHelper.java
+++ b/src/main/java/io/testproject/sdk/internal/addons/AddonsHelper.java
@@ -140,7 +140,7 @@ public class AddonsHelper {
             // Use reflection to set the output value
             proxyField.get().setAccessible(true);
             try {
-                proxyField.get().set(action, field.getValue());
+                proxyField.get().set(action, convertToType(proxyField.get().getType(), (String) field.getValue()));
             } catch (IllegalAccessException e) {
                 LOG.error("Failed to set field [{}] value to [{}]", field.getName(), field.getValue());
             }
@@ -148,5 +148,36 @@ public class AddonsHelper {
 
         // Return potentially updated proxy.
         return action;
+    }
+
+    /**
+     * Convert string to specified type.
+     * @param clazz target type for conversion..
+     * @param value the value that will be converted.
+     * @return value converted to correct type.
+     */
+    private Object convertToType(final Class<?> clazz, final String value) {
+        if (Boolean.class == clazz || boolean.class == clazz) {
+            return Boolean.parseBoolean(value);
+        }
+        if (Byte.class == clazz || byte.class == clazz) {
+            return Byte.parseByte(value);
+        }
+        if (Short.class == clazz || short.class == clazz) {
+            return Short.parseShort(value);
+        }
+        if (Integer.class == clazz || int.class == clazz) {
+            return Integer.parseInt(value);
+        }
+        if (Long.class == clazz || long.class == clazz) {
+            return Long.parseLong(value);
+        }
+        if (Float.class == clazz || float.class == clazz) {
+            return Float.parseFloat(value);
+        }
+        if (Double.class == clazz || double.class == clazz) {
+            return Double.parseDouble(value);
+        }
+        return value;
     }
 }


### PR DESCRIPTION
Convert the string to the relevant type to avoid error where output field could not be set due to type mismatch.