### PR TITLE
Do not cast GenericDriver to RemoteWebDriver when submitting manual test

### DIFF
--- a/src/main/java/io/testproject/sdk/internal/reporting/Reporter.java
+++ b/src/main/java/io/testproject/sdk/internal/reporting/Reporter.java
@@ -17,6 +17,7 @@
 
 package io.testproject.sdk.internal.reporting;
 
+import io.testproject.sdk.drivers.GenericDriver;
 import io.testproject.sdk.drivers.ReportingDriver;
 import io.testproject.sdk.internal.helpers.ReportingCommandsExecutor;
 import io.testproject.sdk.internal.rest.AgentClient;
@@ -220,8 +221,14 @@ public final class Reporter {
      * @return {@link ClosableTestReport} instance
      */
     public ClosableTestReport test(final String name, final boolean passed, final String message) {
-        ReportingCommandsExecutor executor =
-                (ReportingCommandsExecutor) ((RemoteWebDriver) driver).getCommandExecutor();
+
+        ReportingCommandsExecutor executor;
+
+        if (driver instanceof GenericDriver) {
+            executor = driver.getReportingCommandExecutor();
+        } else {
+            executor = (ReportingCommandsExecutor) ((RemoteWebDriver) driver).getCommandExecutor();
+        }
 
         if (!executor.isTestAutoReportsDisabled()) {
             LOG.warn("Automatic test reports is enabled, disable it to report tests manually and avoid duplicates.");


### PR DESCRIPTION
Cast causes runtime error, since GenericDriver is the only driver which does not extend RemoteWebDriver.

Signed-off-by: david_goichman <david.goichman@testproject.io>