### PR TITLE
Close TCP socket connection after reporting queue finishes

### DIFF
--- a/src/main/java/io/testproject/sdk/internal/rest/AgentClient.java
+++ b/src/main/java/io/testproject/sdk/internal/rest/AgentClient.java
@@ -868,6 +868,8 @@ public final class AgentClient implements Closeable {
             reportsExecutorService.shutdown();
         }
 
+        // Make sure to close the socket when exiting.
+        SocketManager.getInstance().closeSocket();
         LOG.info("Session [{}] closed", this.getSession().getSessionId());
     }
 

--- a/src/main/java/io/testproject/sdk/internal/tcp/SocketManager.java
+++ b/src/main/java/io/testproject/sdk/internal/tcp/SocketManager.java
@@ -58,8 +58,6 @@ public final class SocketManager {
      * Private constructor to prevent creating more than one instance.
      */
     private SocketManager() {
-        // Make sure to close the socket when process exits
-        Runtime.getRuntime().addShutdownHook(new Thread(this::closeSocket));
     }
 
     /**


### PR DESCRIPTION
Close the socket only after finishing reporting to prevent missing reporting driver commands and tests, as well as to prevent a 417 error that is caused by the agent leaving development mode before reporting is finished.