### PR TITLE
Close TCP socket connection after reporting queue finishes

### DIFF
--- a/src/main/java/io/testproject/sdk/internal/rest/AgentClient.java
+++ b/src/main/java/io/testproject/sdk/internal/rest/AgentClient.java
@@ -840,11 +840,15 @@ public final class AgentClient implements Closeable {
         close();
     }
 
+
     /**
      * Implementation of {@link Closeable Closable} interface.
-     * Close all open resources such as the reporting queue and the TCP socket open with the Agent.
+     * Closes all open resources such as the reporting queue without closing
+     * the TCP socket open with the agent.
      */
     public void close() {
+        close(false);
+    }
 
     /**
      * Close all open resources such as the reporting queue and the TCP socket open with the Agent

--- a/src/main/java/io/testproject/sdk/internal/rest/AgentClient.java
+++ b/src/main/java/io/testproject/sdk/internal/rest/AgentClient.java
@@ -243,8 +243,8 @@ public final class AgentClient implements Closeable {
             this.reportsQueueFuture = reportsExecutorService.submit(this.reportsQueue);
         }
 
-        // Make sure to exit gracefully
-        shutdownThread = new Thread(this::close);
+        // Make sure to exit gracefully and close the development socket
+        shutdownThread = new Thread(() -> close(true));
         Runtime.getRuntime().addShutdownHook(shutdownThread);
     }
 

--- a/src/main/java/io/testproject/sdk/internal/rest/AgentClient.java
+++ b/src/main/java/io/testproject/sdk/internal/rest/AgentClient.java
@@ -876,6 +876,12 @@ public final class AgentClient implements Closeable {
             reportsExecutorService.shutdown();
         }
 
+        // Make sure to close the socket when exiting.
+        if (exiting) {
+            LOG.debug("Agent client is closing development socket as process is exiting...");
+            SocketManager.getInstance().closeSocket();
+        }
+
         LOG.info("Session [{}] closed", this.getSession().getSessionId());
     }
 

--- a/src/main/java/io/testproject/sdk/internal/rest/AgentClient.java
+++ b/src/main/java/io/testproject/sdk/internal/rest/AgentClient.java
@@ -845,6 +845,14 @@ public final class AgentClient implements Closeable {
      * Close all open resources such as the reporting queue and the TCP socket open with the Agent.
      */
     public void close() {
+
+    /**
+     * Close all open resources such as the reporting queue and the TCP socket open with the Agent
+     * if the process is exiting.
+     *
+     * @param exiting used to determine if the socket should be closed.
+     */
+    public void close(final boolean exiting) {
         LOG.trace("Closing AgentClient for driver session [{}]", this.getSession().getSessionId());
         if (reportsQueueFuture != null && !reportsQueueFuture.isDone()) {
             reportsQueue.stop();

--- a/src/main/java/io/testproject/sdk/internal/tcp/SocketManager.java
+++ b/src/main/java/io/testproject/sdk/internal/tcp/SocketManager.java
@@ -58,8 +58,6 @@ public final class SocketManager {
      * Private constructor to prevent creating more than one instance.
      */
     private SocketManager() {
-        // Make sure to close the socket when process exits
-        Runtime.getRuntime().addShutdownHook(new Thread(this::closeSocket));
     }
 
     /**


### PR DESCRIPTION
@mstrelex Changes we discussed.

The socket will be closed only after a flag is raised that the Agent client is finishing and there is no need for session reuse.