### PR TITLE
Fix Issue Where Auto Reports Were Not Disabled When Running Cucumber

### DIFF
--- a/src/main/java/io/testproject/sdk/internal/reporting/Reporter.java
+++ b/src/main/java/io/testproject/sdk/internal/reporting/Reporter.java
@@ -58,7 +58,7 @@ public final class Reporter {
     public Reporter(final ReportingDriver driver, final AgentClient agentClient) {
         this.agentClient = agentClient;
         this.driver = driver;
-        if (Boolean.getBoolean(System.getProperty("TP_DISABLE_AUTO_REPORTS"))) {
+        if (Boolean.getBoolean("TP_DISABLE_AUTO_REPORTS")) {
             this.disableTestAutoReports(true);
             this.disableCommandReports(true);
         }

--- a/src/main/java/io/testproject/sdk/internal/rest/AgentClient.java
+++ b/src/main/java/io/testproject/sdk/internal/rest/AgentClient.java
@@ -759,7 +759,7 @@ public final class AgentClient implements Closeable {
         LOG.info("Using [{}] and [{}] for Project and Job names accordingly.",
                 result.getProjectName(), result.getJobName());
 
-        if (Boolean.getBoolean(System.getProperty("TP_DISABLE_AUTO_REPORTS"))) {
+        if (Boolean.getBoolean("TP_DISABLE_AUTO_REPORTS")) {
             skipInferring = true;
         }
 


### PR DESCRIPTION
getBoolean always performs System.getProperty internally, while using it externally, it would check
for a system property called "true"/"false" internally and always return false since it does not exist,
causing the auto reports to never be disabled.

Signed-off-by: david_goichman <david.goichman@testproject.io>